### PR TITLE
rewrite the pn pubsub engine to handle multiple subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "clean": "rimraf dist",
     "compile": "tsc --build tsconfig.json",
     "prepublish": "npm run compile",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "test:ts": "mocha -r ts-node/register src/**/*.tests.ts"
+    "dev": "npm run compile -- --watch",
+    "test": "mocha -r ts-node/register src/**/*.tests.ts --watch"
   },
   "repository": {
     "type": "git",

--- a/src/pn-pubsub.ts
+++ b/src/pn-pubsub.ts
@@ -177,7 +177,7 @@ export class PNPubSub implements PubSubEngine {
         channels: [channel]
       });
     }
-    this.subsRefsMap[channel] = refs?.filter(([id]) => id === subscribeId)
+    this.subsRefsMap[channel] = refs?.filter(([id]) => id !== subscribeId)
   }
 
   public asyncIterator<T>(channels: string | string[]): AsyncIterator<T> {

--- a/src/pn-pubsub.ts
+++ b/src/pn-pubsub.ts
@@ -7,9 +7,9 @@ import PubNub from 'pubnub';
  * This is the minimum simple options passed to the JS SDK object
  */
 type PNOptions = {
-  subscribeKey: String;
-  publishKey: String;
-  origin?: String;
+  subscribeKey: string;
+  publishKey: string;
+  origin?: string;
   debug?: boolean;
   client?: PubNub;
 };
@@ -22,14 +22,17 @@ type PNOptions = {
  * returned fields. Any additional fields used in the GraphQL Schema must be properly
  * resolved either manually or added to this library for resolution.
  */
+
 type PNMessage = {
-  channel: String;
-  actualChannel?: String;
-  subscribedChannel: String;
-  timetoken: String;
-  publisher: String;
+  channel: string;
+  actualChannel?: string;
+  subscribedChannel: string;
+  timetoken: string;
+  publisher: string;
   message: any;
 };
+
+type OnMessage = (message: PNMessage) => void;
 
 /**
  * The PubNub specific class that is to be used to translate GraphQL subscriptions
@@ -39,15 +42,54 @@ type PNMessage = {
  * The current PubNub message listener is attached to the pubsub-async-iterator class
  * in order to produce an AsyncIterator equivalent for GraphQL to process.
  */
+
+
+/**
+ * A class for the pubnub pubsub engine which is responsible for:
+ * 1) Adding a single listener that listens to all subscribed channel and class the appropirate rsolver
+ * 2) Subscribing to pubnub channels when a subscriptioin is active
+ * 3) Unsubscribing from a pubnub channel when all subscription clients to this channel unsubscribe
+ * @class
+ *
+ * @constructor
+ *
+ * setsup a single listener to pubnub which chooses the appriporiate handler to call
+ *
+ * @property pubnub @type {PubNub}
+ * The pubnub instance
+ *
+ * @property subscribeId @type {number}
+ * Incremented counter that's used to get a new id for a new subscrption .. needed for promise tracking
+ *
+ * @property subscriptions @type {{ [subscribeId: number]: string }}
+ * An object that keeps refrence of which subscription has which channel. Useful when we try to unsubscribe
+ * from a channel to resolve the channel name by id
+ *
+ *
+ * @property subsRefsMap @type {{[channel: string]: [number, OnMessage][]}}
+ * An object that is useful to determine which channel has which subscriptions and handlers
+ * Userful in multiple places:
+ * 1) The event listener callback to pick which resolvers to call
+ * 2) subscribe function to see if the channel's already been subscribed to
+ * 3) unsubscribe to see if we actually need to unsubscribe from the channel or there are still some
+ * clients that need this pubnub subscription going
+ *
+ * @property debug @type {boolean}
+ * A boolean that is set on initialization to determine if the server (preferably on dev environment) needs some useful console logs
+ */
+
+
 export class PNPubSub implements PubSubEngine {
   private pubnub: PubNub;
   private subscribeId: number;
-  private channels: string[];
+  private subscriptions: { [subscribeId: number]: string };
+  private subsRefsMap: {[channel: string]: [number, OnMessage][]};
   private debug: boolean;
 
   constructor({ debug, client, ...options }: PNOptions) {
     this.subscribeId = 0; // this is needed for promise tracking
-    this.channels = []; // list of channels we're subscribed to
+    this.subscriptions = {};
+    this.subsRefsMap = {};
     this.debug = debug;
 
     if (this.debug) {
@@ -62,6 +104,12 @@ export class PNPubSub implements PubSubEngine {
     } else {
       this.pubnub = new PubNub(options);
     }
+
+    this.pubnub.addListener({ message: (message: PNMessage) => {
+      this.subsRefsMap[message.channel].forEach(([_, onMessage]) => onMessage(message))
+    }
+  });
+
   }
 
   public getClientInstance(): PubNub {
@@ -82,31 +130,54 @@ export class PNPubSub implements PubSubEngine {
 
   public subscribe(
     channel: string,
-    onMessage: Function,
-    options: Object
+    onMessage: OnMessage,
   ): Promise<number> {
+
     const id = this.subscribeId++;
+    this.subscriptions[id] = channel;
+
+    const refs = this.subsRefsMap[channel]
+
+    if (refs && refs.length > 0) {
+      refs.push([id, onMessage])
+      if (this.debug) {
+        // eslint disable-next-line
+        console.debug(`Already Subscribed to: ${channel}`);
+      }
+      return Promise.resolve(id);
+    }
 
     if (this.debug) {
       // eslint disable-next-line
-      console.debug(`Now subscribing to: ${[...this.channels, channel]}`);
+      console.debug(`Now subscribing to: ${channel}`);
     }
 
-    // Add the message listener
-    this.pubnub.addListener({ message: onMessage });
-
-    this.pubnub.subscribe({ channels: [...this.channels, channel] });
-
+    this.subsRefsMap[channel] = [[id, onMessage]]
+    this.pubnub.subscribe({ channels: [channel] });
     return Promise.resolve(id);
   }
 
   public unsubscribe(subscribeId: number) {
     if (this.debug) {
       // eslint disable-next-line
-      console.debug(`Unsubscribing to all`);
+      console.debug(`Unsubscribing to ${subscribeId}`);
     }
 
-    return this.pubnub.unsubscribeAll();
+    const channel = this.subscriptions[subscribeId]
+    delete this.subscriptions[subscribeId]
+    const refs = this.subsRefsMap[channel]
+
+    if (refs?.length === 1) {
+      if (this.debug) {
+        // eslint disable-next-line
+        console.debug(`Unsubscribing to channel ${channel}`);
+      }
+      delete this.subsRefsMap[channel]
+      return this.pubnub.unsubscribe({
+        channels: [channel]
+      });
+    }
+    this.subsRefsMap[channel] = refs?.filter(([id]) => id === subscribeId)
   }
 
   public asyncIterator<T>(channels: string | string[]): AsyncIterator<T> {


### PR DESCRIPTION
refer to issue https://github.com/pubnub/graphql-pubnub-subscriptions/issues/3 
- Remove the `pubnub` even listener from the `subscribe` call to the constructor so we have to register only one event listener. 
- The reason for that is `pubnub` will call the event listener handler for every message on every channel not knowing which handler is for which `graphql` subscription.
- what `subscribe`  now does is add the handler to an array under each channel (this array would represent different `qraphql` subscription to the same channel). and when any message in any channel is sent: the single event listener will call each function in this array.
- Change how `unsubscribe` instead of just calling `pubnub.unsubsribeAll` to look for the channel name using the `subscriptionId` and this channel name checks if there are any other subscribers first.
- If there are other subscribers to this channel it just removes the ref of this subscription that is trying to unsubscribe.
- If this is the only subscription to the channel we actually unsubscribes and remove the channel reference entirely.